### PR TITLE
remove unneeded boolean combo in add

### DIFF
--- a/sources/signed64.move
+++ b/sources/signed64.move
@@ -45,7 +45,7 @@ module safe64::signed64 {
                 (b, a)
             };
 
-            new(larger.magnitude - smaller.magnitude, larger.negative && !smaller.negative)
+            new(larger.magnitude - smaller.magnitude, larger.negative)
         }
     }
 


### PR DESCRIPTION
this is always true && true or false && false because of the above checks

just use one check instead